### PR TITLE
Enhance CI/CD pipeline with image digest retrieval and update Lambda configurations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,8 +70,13 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
+          # Get the SHA digest of the pushed image
+          IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG | cut -d'@' -f2)
+
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG" >> $GITHUB_OUTPUT
           echo "version_tag=$VERSION_TAG" >> $GITHUB_OUTPUT
+          echo "image_digest=$IMAGE_DIGEST" >> $GITHUB_OUTPUT
+          echo "image_with_digest=$ECR_REGISTRY/$ECR_REPOSITORY@$IMAGE_DIGEST" >> $GITHUB_OUTPUT
 
   deploy:
     needs: [test, build-and-push]
@@ -104,6 +109,23 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "commit_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
           echo "Deployment version: $VERSION, Commit: ${{ github.sha }}"
+      - name: Get image digests from ECR
+        id: get_digests
+        run: |
+          # Get the ECR registry URL
+          ECR_REGISTRY=$(aws ecr describe-registry --query 'registryId' --output text).dkr.ecr.us-east-1.amazonaws.com
+          VERSION_TAG="v${{ steps.deploy_version.outputs.version }}"
+
+          # Get digests for each component
+          PARAM_GENERATOR_DIGEST=$(aws ecr describe-images --repository-name fest-vibes-ai-param_generator --image-ids imageTag=$VERSION_TAG --query 'imageDetails[0].imageDigest' --output text)
+          EXTRACTOR_DIGEST=$(aws ecr describe-images --repository-name fest-vibes-ai-extractor --image-ids imageTag=$VERSION_TAG --query 'imageDetails[0].imageDigest' --output text)
+          LOADER_DIGEST=$(aws ecr describe-images --repository-name fest-vibes-ai-loader --image-ids imageTag=$VERSION_TAG --query 'imageDetails[0].imageDigest' --output text)
+          CACHE_MANAGER_DIGEST=$(aws ecr describe-images --repository-name fest-vibes-ai-cache_manager --image-ids imageTag=$VERSION_TAG --query 'imageDetails[0].imageDigest' --output text)
+
+          echo "param_generator_digest=$PARAM_GENERATOR_DIGEST" >> $GITHUB_OUTPUT
+          echo "extractor_digest=$EXTRACTOR_DIGEST" >> $GITHUB_OUTPUT
+          echo "loader_digest=$LOADER_DIGEST" >> $GITHUB_OUTPUT
+          echo "cache_manager_digest=$CACHE_MANAGER_DIGEST" >> $GITHUB_OUTPUT
       - name: Create terraform.tfvars
         run: |
           cd terraform/environments/prod
@@ -114,6 +136,10 @@ jobs:
           base_url = "${{ secrets.BASE_URL }}"
           s3_bucket_name = "${{ secrets.S3_BUCKET_NAME }}"
           image_version = "v${{ steps.deploy_version.outputs.version }}"
+          param_generator_image_digest = "${{ steps.get_digests.outputs.param_generator_digest }}"
+          extractor_image_digest = "${{ steps.get_digests.outputs.extractor_digest }}"
+          loader_image_digest = "${{ steps.get_digests.outputs.loader_digest }}"
+          cache_manager_image_digest = "${{ steps.get_digests.outputs.cache_manager_digest }}"
           EOF
       - name: Terraform Apply
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,8 @@ serialize = ["{major}.{minor}.{patch}"]
 filename = "pyproject.toml"
 search = "version = \"{current_version}\""
 replace = "version = \"{new_version}\""
+
+[[tool.bump_my_version.files]]
+filename = "pyproject.toml"
+search = "current_version = \"{current_version}\""
+replace = "current_version = \"{new_version}\""

--- a/terraform/environments/prod/lambda.tf
+++ b/terraform/environments/prod/lambda.tf
@@ -25,7 +25,7 @@ resource "aws_lambda_function" "param_generator" {
   description   = "Generates date ranges for ETL pipeline"
   role          = aws_iam_role.lambda_execution_role.arn
   package_type  = "Image"
-  image_uri     = "${aws_ecr_repository.param_generator.repository_url}:${var.image_version}"
+  image_uri     = var.param_generator_image_digest != "" ? "${aws_ecr_repository.param_generator.repository_url}@${var.param_generator_image_digest}" : "${aws_ecr_repository.param_generator.repository_url}:${var.image_version}"
   timeout       = 300
   memory_size   = 512
 
@@ -48,7 +48,7 @@ resource "aws_lambda_function" "extractor" {
   description   = "Extracts event data from website"
   role          = aws_iam_role.lambda_execution_role.arn
   package_type  = "Image"
-  image_uri     = "${aws_ecr_repository.extractor.repository_url}:${var.image_version}"
+  image_uri     = var.extractor_image_digest != "" ? "${aws_ecr_repository.extractor.repository_url}@${var.extractor_image_digest}" : "${aws_ecr_repository.extractor.repository_url}:${var.image_version}"
   timeout       = 300
   memory_size   = 1024
 
@@ -75,7 +75,7 @@ resource "aws_lambda_function" "loader" {
   description   = "Loads data from S3 to database"
   role          = aws_iam_role.lambda_execution_role.arn
   package_type  = "Image"
-  image_uri     = "${aws_ecr_repository.loader.repository_url}:${var.image_version}"
+  image_uri     = var.loader_image_digest != "" ? "${aws_ecr_repository.loader.repository_url}@${var.loader_image_digest}" : "${aws_ecr_repository.loader.repository_url}:${var.image_version}"
   timeout       = 300
   memory_size   = 1024
 
@@ -104,7 +104,7 @@ resource "aws_lambda_function" "cache_manager" {
   description   = "Updates Redis cache with event data"
   role          = aws_iam_role.lambda_execution_role.arn
   package_type  = "Image"
-  image_uri     = "${aws_ecr_repository.cache_manager.repository_url}:${var.image_version}"
+  image_uri     = var.cache_manager_image_digest != "" ? "${aws_ecr_repository.cache_manager.repository_url}@${var.cache_manager_image_digest}" : "${aws_ecr_repository.cache_manager.repository_url}:${var.image_version}"
   timeout       = 300
   memory_size   = 512
 

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -35,6 +35,30 @@ variable "image_version" {
   default     = "latest"
 }
 
+variable "param_generator_image_digest" {
+  description = "SHA256 digest of param_generator container image"
+  type        = string
+  default     = ""
+}
+
+variable "extractor_image_digest" {
+  description = "SHA256 digest of extractor container image"
+  type        = string
+  default     = ""
+}
+
+variable "loader_image_digest" {
+  description = "SHA256 digest of loader container image"
+  type        = string
+  default     = ""
+}
+
+variable "cache_manager_image_digest" {
+  description = "SHA256 digest of cache_manager container image"
+  type        = string
+  default     = ""
+}
+
 variable "user_agent" {
   description = "User agent string for web scraping requests"
   type        = string


### PR DESCRIPTION
# Branch Summary: feat/remove-imports-from-tf-simplify-cicd

## Overview

This branch focused on fixing critical CI/CD pipeline issues and implementing Lambda image deployment improvements to ensure reliable deployments.

## Issues Fixed

### 1. Step Functions Import ARN Error

**Problem**: Terraform import statement was using an incomplete ARN for the Step Functions state machine

- **File**: `terraform/environments/prod/step-function.tf`
- **Error**: `Invalid ARN prefix: fest-vibes-ai-etl-pipeline`
- **Root Cause**: Import block used just the name instead of full ARN format
- **Fix**: Updated line 10 from:

  ```hcl
  id = "fest-vibes-ai-etl-pipeline"
  ```

  to:

  ```hcl
  id = "arn:aws:states:us-east-1:937355130135:stateMachine:fest-vibes-ai-etl-pipeline"
  ```

### 2. Version Bumping System Failure

**Problem**: CI/CD version bumping step was failing with "No such command 'patch'" error

- **Files**: `.github/workflows/main.yml` and `pyproject.toml`
- **Root Causes**:
  1. Wrong command syntax: `bump-my-version patch` instead of `bump-my-version bump patch`
  2. Configuration mismatch: `[tool.bumpversion]` instead of `[tool.bump_my_version]`
- **Fixes**:
  1. **Workflow**: Updated command to `bump-my-version bump patch`
  2. **Config**: Changed `[tool.bumpversion]` to `[tool.bump_my_version]` in pyproject.toml
  3. **Config**: Updated `[[tool.bumpversion.files]]` to `[[tool.bump_my_version.files]]`

### 3. Lambda Image Update Issue

**Problem**: Lambda functions were not updating when new images were built because they used version tags that might reference stale images

- **Root Cause**: Lambda `image_uri` used version tags (e.g., `v0.0.1`) which could point to old images if the same version was reused
- **Files**: `.github/workflows/main.yml`, `terraform/environments/prod/lambda.tf`, `terraform/environments/prod/variables.tf`
- **Solution**: Implemented SHA digest-based image references for guaranteed updates

**Implementation**:

1. **Enhanced CI/CD Pipeline**:
   - Added ECR image digest retrieval step
   - Pipeline now fetches SHA256 digests for each component after build

2. **Updated Terraform Configuration**:
   - Added digest variables: `param_generator_image_digest`, `extractor_image_digest`, `loader_image_digest`, `cache_manager_image_digest`
   - Modified Lambda `image_uri` to use SHA digests when available, fallback to version tags
   - Format: `repository_url@sha256:digest` instead of `repository_url:version_tag`

3. **Updated terraform.tfvars Generation**:
   - Pipeline now passes SHA digests alongside version information
   - Ensures Lambda functions always use the exact image that was built

## Impact

- Terraform deployment now succeeds without ARN prefix errors
- Version bumping works correctly after successful pipeline runs
- Lambda functions reliably update with new images on every deployment
- SHA digest-based deployment eliminates stale image issues
- CI/CD pipeline can complete end-to-end without failures
- Automated versioning and tagging restored

## Files Modified

- `terraform/environments/prod/step-function.tf`
- `terraform/environments/prod/lambda.tf`
- `terraform/environments/prod/variables.tf`
- `.github/workflows/main.yml`
- `pyproject.toml`

## Technical Details

**Lambda Image URI Strategy**:
- **Before**: `${repository_url}:${version_tag}` (could reference stale images)
- **After**: `${repository_url}@${sha256_digest}` (immutable, unique per build)
- **Fallback**: Maintains version tag support for backward compatibility

**Benefits**:
- Guaranteed Lambda updates on every deployment
- Immutable image references prevent deployment inconsistencies
- Terraform reliably detects changes due to unique SHA digests

## Next Steps

The pipeline should now run successfully from test → build → deploy → version bump with reliable Lambda updates on every deployment.